### PR TITLE
Scaling benchmark and script

### DIFF
--- a/scripts/scaling.py
+++ b/scripts/scaling.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import csv
+import os
+import pathlib
+import re
+import subprocess
+
+def run_scaling_benchmark(name):
+    cwd = os.getcwd()
+    exe = pathlib.Path(cwd) / "../build/simplicial_arrangement_tests"
+    assert(exe.exists())
+    r = subprocess.check_output([exe, name]).decode('ascii')
+    return r
+
+def parse_timing(name, text):
+    header_pattern = re.compile("\s*(\d*)\s*planes")
+    time_pattern = re.compile("\s*(\d*.\d*)\s*([um]?s)")
+
+    plane_counts = []
+    means = []
+    std_devs = []
+
+    chunks = text.split("3D {}".format(name))
+    for c in chunks:
+        lines = c.splitlines()
+        r0 = header_pattern.match(lines[0])
+        r1 = time_pattern.match(lines[1])
+        r2 = time_pattern.match(lines[2])
+        if r0 is None or r1 is None or r2 is None: continue
+
+        num_planes = r0.group(1)
+        mean = float(r1.group(1))
+        std_dev = float(r2.group(1))
+        if (r1.group(2) == "ms"): mean *= 1e-3
+        elif (r1.group(2) == "us"): mean *= 1e-6
+        elif (r1.group(2) == "ns"): mean *= 1e-9
+        if (r2.group(2) == "ms"): std_dev *= 1e-3
+        elif (r2.group(2) == "us"): std_dev *= 1e-6
+        elif (r2.group(2) == "ns"): std_dev *= 1e-9
+
+        print("{} planes: mean={}s  std_dev={}s".format(num_planes, mean,
+            std_dev))
+        plane_counts.append(num_planes)
+        means.append(mean)
+        std_devs.append(std_dev)
+
+    return plane_counts, means, std_devs
+
+def export_csv(filename, data):
+    num_planes, means, std_devs = data
+    with open(filename, 'w') as fout:
+        writer = csv.writer(fout)
+        writer.writerow(["num_planes", "mean", "std_dev"])
+        num_entries = len(num_planes)
+        for i in range(num_entries):
+            writer.writerow([num_planes[i], means[i], std_devs[i]])
+
+if __name__ == "__main__":
+    r = run_scaling_benchmark("arrangement_scaling")
+    data = parse_timing("ar", r)
+    export_csv("arrangement_scaling.csv", data)
+
+    r = run_scaling_benchmark("material_interface_scaling")
+    data = parse_timing("mi", r)
+    export_csv("material_interface_scaling.csv", data)
+

--- a/scripts/scaling.r
+++ b/scripts/scaling.r
@@ -1,0 +1,23 @@
+library(ggplot2)
+
+data <- read.csv("arrangement_scaling.csv")
+summary(data)
+
+p <- ggplot(data)
+p <- p + geom_errorbar(aes(x=num_planes, y=mean, ymax = mean + std_dev, ymin = mean - std_dev), color="darkgray")
+p <- p + geom_point(aes(num_planes, mean))
+p <- p + theme_minimal()
+p <- p + scale_x_continuous(breaks = round(seq(10, 100, by = 10),1))
+p <- p + ylab("Time (s)") + xlab("Number of functions") + ggtitle("Arrangement Scaling")
+ggsave("arrangement_scaling.pdf", width=3, height=2, unit="in")
+
+data <- read.csv("material_interface_scaling.csv")
+summary(data)
+
+p <- ggplot(data)
+p <- p + geom_errorbar(aes(x=num_planes, y=mean, ymax = mean + std_dev, ymin = mean - std_dev), color="darkgray")
+p <- p + geom_point(aes(num_planes, mean))
+p <- p + theme_minimal()
+p <- p + scale_x_continuous(breaks = round(seq(10, 100, by = 10),1))
+p <- p + ylab("Time (s)") + xlab("Number of functions") + ggtitle("Material Interface Scaling")
+ggsave("material_interface_scaling.pdf", width=3, height=2, unit="in")

--- a/tests/scaling.cpp
+++ b/tests/scaling.cpp
@@ -1,0 +1,59 @@
+#include <simplicial_arrangement/lookup_table.h>
+#include <simplicial_arrangement/material_interface.h>
+#include <simplicial_arrangement/simplicial_arrangement.h>
+
+#include <spdlog/spdlog.h>
+
+#include <catch2/catch.hpp>
+#include <random>
+#include <vector>
+
+TEST_CASE("arrangement_scaling", "[ar][scaling][.benchmark]")
+{
+    using namespace simplicial_arrangement;
+    std::mt19937 gen(7);
+    std::uniform_int_distribution<> distrib(-(1 << 12), 1 << 12);
+
+    for (size_t n = 10; n <= 100; n += 10) {
+        BENCHMARK_ADVANCED(fmt::format("3D ar {} planes", n))
+        (Catch::Benchmark::Chronometer meter)
+        {
+            disable_lookup_table();
+            std::vector<Plane<double, 3>> planes;
+            planes.reserve(n);
+            for (size_t i = 0; i < n; i++) {
+                planes.push_back({static_cast<double>(distrib(gen)),
+                    static_cast<double>(distrib(gen)),
+                    static_cast<double>(distrib(gen)),
+                    static_cast<double>(distrib(gen))});
+            }
+
+            meter.measure([&]() { return compute_arrangement(planes); });
+        };
+    }
+}
+
+TEST_CASE("material_interface_scaling", "[mi][scaling][.benchmark]")
+{
+    using namespace simplicial_arrangement;
+    std::mt19937 gen(7);
+    std::uniform_int_distribution<> distrib(-(1 << 12), 1 << 12);
+
+    for (size_t n = 10; n <= 100; n += 10) {
+        BENCHMARK_ADVANCED(fmt::format("3D mi {} planes", n))
+        (Catch::Benchmark::Chronometer meter)
+        {
+            disable_lookup_table();
+            std::vector<Material<double, 3>> planes;
+            planes.reserve(n);
+            for (size_t i = 0; i < n; i++) {
+                planes.push_back({static_cast<double>(distrib(gen)),
+                    static_cast<double>(distrib(gen)),
+                    static_cast<double>(distrib(gen)),
+                    static_cast<double>(distrib(gen))});
+            }
+
+            meter.measure([&]() { return compute_material_interface(planes); });
+        };
+    }
+}


### PR DESCRIPTION
Summary:
* Add scaling benchmark.  e.g. `simplical_arrangement_tests arrangement_scaling`.
* Add script to convert benchmark output into plot.

Usage:
```sh
cd script
./scaling.py  # This will run benchmark and save result as csv files.
Rscript scaling.r  # To generate plots.
```