### PR TITLE
Unique plane convention update for Arrangement

### DIFF
--- a/app/implicit_arrangement_util.cpp
+++ b/app/implicit_arrangement_util.cpp
@@ -681,6 +681,7 @@ void extract_iso_mesh(const std::vector<bool>& has_isosurface,
             const auto& arrangement = cut_results[i];
             const auto& vertices = arrangement.vertices;
             const auto& faces = arrangement.faces;
+            const bool all_unique = arrangement.unique_planes.empty();
             const auto& func_ids = func_in_tet.row(i);
             auto num_func = num_func_in_tet(i);
             // find vertices and faces on isosurface
@@ -688,14 +689,23 @@ void extract_iso_mesh(const std::vector<bool>& has_isosurface,
             std::vector<bool> is_iso_face(faces.size(), false);
             for (size_t j = 0; j < faces.size(); j++) {
                 auto pid = faces[j].supporting_plane;
-                auto uid = arrangement.unique_plane_indices[pid];
-                for (const auto& plane_id : arrangement.unique_planes[uid]) {
-                    if (plane_id > 3) { // plane 0,1,2,3 are tet boundaries
+                if (all_unique) {
+                    if (pid > 3) {
                         is_iso_face[j] = true;
                         for (const auto& vid : faces[j].vertices) {
                             is_iso_vert[vid] = true;
                         }
-                        break;
+                    }
+                } else {
+                    auto uid = arrangement.unique_plane_indices[pid];
+                    for (const auto& plane_id : arrangement.unique_planes[uid]) {
+                        if (plane_id > 3) { // plane 0,1,2,3 are tet boundaries
+                            is_iso_face[j] = true;
+                            for (const auto& vid : faces[j].vertices) {
+                                is_iso_vert[vid] = true;
+                            }
+                            break;
+                        }
                     }
                 }
             }
@@ -928,6 +938,7 @@ void extract_iso_mesh_pure(size_t num_1_func,
             const auto& arrangement = cut_results[cut_result_index[i]];
             const auto& vertices = arrangement.vertices;
             const auto& faces = arrangement.faces;
+            const bool all_unique = arrangement.unique_planes.empty();
             //            const auto& func_ids = func_in_tet.row(i);
             //            auto num_func = num_func_in_tet(i);
             auto start_index = start_index_of_tet[i];
@@ -943,15 +954,24 @@ void extract_iso_mesh_pure(size_t num_1_func,
             for (size_t j = 0; j < faces.size(); j++) {
                 is_iso_face.push_back(false);
                 auto pid = faces[j].supporting_plane;
-                auto uid = arrangement.unique_plane_indices[pid];
-                for (const auto& plane_id : arrangement.unique_planes[uid]) {
-                    if (plane_id > 3) { // plane 0,1,2,3 are tet boundaries
-                        //                        is_iso_face[j] = true;
+                if (all_unique) {
+                    if (pid > 3) {
                         is_iso_face.back() = true;
                         for (const auto& vid : faces[j].vertices) {
                             is_iso_vert[vid] = true;
                         }
-                        break;
+                    }
+                } else {
+                    auto uid = arrangement.unique_plane_indices[pid];
+                    for (const auto& plane_id : arrangement.unique_planes[uid]) {
+                        if (plane_id > 3) { // plane 0,1,2,3 are tet boundaries
+                            //                        is_iso_face[j] = true;
+                            is_iso_face.back() = true;
+                            for (const auto& vid : faces[j].vertices) {
+                                is_iso_vert[vid] = true;
+                            }
+                            break;
+                        }
                     }
                 }
             }
@@ -1205,6 +1225,7 @@ void extract_iso_mesh_marching_tet(const std::vector<bool>& has_isosurface,
             const auto& arrangement = cut_results[i];
             const auto& vertices = arrangement.vertices;
             const auto& faces = arrangement.faces;
+            const bool all_unique = arrangement.unique_planes.empty();
             // const auto& func_ids = func_in_tet[i];
             //auto num_func = func_ids.size();  // num_func = 1
             // find vertices and faces on isosurface
@@ -1212,14 +1233,23 @@ void extract_iso_mesh_marching_tet(const std::vector<bool>& has_isosurface,
             std::vector<bool> is_iso_face(faces.size(), false);
             for (size_t j = 0; j < faces.size(); j++) {
                 auto pid = faces[j].supporting_plane;
-                auto uid = arrangement.unique_plane_indices[pid];
-                for (const auto& plane_id : arrangement.unique_planes[uid]) {
-                    if (plane_id > 3) { // plane 0,1,2,3 are tet boundaries
+                if (all_unique) {
+                    if (pid > 3) {
                         is_iso_face[j] = true;
                         for (const auto& vid : faces[j].vertices) {
                             is_iso_vert[vid] = true;
                         }
-                        break;
+                    }
+                } else {
+                    auto uid = arrangement.unique_plane_indices[pid];
+                    for (const auto& plane_id : arrangement.unique_planes[uid]) {
+                        if (plane_id > 3) { // plane 0,1,2,3 are tet boundaries
+                            is_iso_face[j] = true;
+                            for (const auto& vid : faces[j].vertices) {
+                                is_iso_vert[vid] = true;
+                            }
+                            break;
+                        }
                     }
                 }
             }

--- a/include/simplicial_arrangement/simplicial_arrangement.h
+++ b/include/simplicial_arrangement/simplicial_arrangement.h
@@ -104,6 +104,8 @@ struct Arrangement
     std::vector<Face> faces;
     std::vector<Cell> cells;
 
+    // Note: the following structure is only non-empty if input planes contain
+    // duplicates.
     std::vector<size_t> unique_plane_indices;
     std::vector<std::vector<size_t>> unique_planes;
     std::vector<bool> unique_plane_orientations;

--- a/src/ArrangementBuilder.h
+++ b/src/ArrangementBuilder.h
@@ -28,15 +28,22 @@ public:
         const size_t num_planes = m_planes.get_num_planes();
         m_coplanar_planes.init(num_planes + DIM + 1);
         auto ar_complex = initialize_simplicial_ar_complex<DIM>(num_planes + DIM + 1);
+        size_t unique_plane_count = 0;
         for (size_t i = 0; i < num_planes; i++) {
             size_t plane_id = i + DIM + 1;
             size_t coplanar_plane_id = internal::add_plane(m_planes, ar_complex, plane_id);
             if (coplanar_plane_id != INVALID) {
                 m_coplanar_planes.merge(plane_id, coplanar_plane_id);
+            } else {
+                unique_plane_count++;
             }
         }
         m_arrangement = extract_arrangement(std::move(ar_complex));
-        extract_unique_planes();
+        if (unique_plane_count != num_planes) {
+            // Only popularize unqiue plane structure if duplicate planes are
+            // detected.
+            extract_unique_planes();
+        }
     }
 
     const Arrangement<DIM>& get_arrangement() const { return m_arrangement; }


### PR DESCRIPTION
Summary:
* Adopt the convention that empty `unique_planes` means all planes are unique.
* Update unit tests and other code to use this convention.